### PR TITLE
cleanup attributes, docstring; remove unused array

### DIFF
--- a/python/src/rfcde/core.py
+++ b/python/src/rfcde/core.py
@@ -95,6 +95,8 @@ class RFCDE(object):
         self.basis_system = basis_system
         self.lens = None
         self.forest = ForestWrapper()
+        self.n_var = None
+        self.fit_oob = False
 
     def train(self, x_train, z_train, lens=None, flambda=1.0, fit_oob=False):
         """Train RFCDE object on training data.
@@ -152,7 +154,7 @@ class RFCDE(object):
 
         Arguments
         ---------
-        x_test : numpy array
+        x_new : numpy array
             A new observation.
 
         Returns

--- a/python/src/rfcde/kde.py
+++ b/python/src/rfcde/kde.py
@@ -33,7 +33,6 @@ def kde(responses, grid, weights, bandwidth):
     """
     n_grid, n_dim = grid.shape
     n_obs, _ = responses.shape
-    density = np.zeros(n_grid)
 
     responses = responses[weights > 0, :]
     weights = weights[weights > 0]


### PR DESCRIPTION
Changes:
* Set missing RFCDE instance attributes in `__init__`
* Fix arg name to `x_new` in `RFCDE.weights` method docstring
* Remove unused numpy array, `density`, in `kde` function